### PR TITLE
Adhoc signing

### DIFF
--- a/bin/isign
+++ b/bin/isign
@@ -282,7 +282,7 @@ if __name__ == '__main__':
                            'deep',
                            'key',
                            'apple_cert',
-                           'provisioning_profile',
+			   'provisioning_profiles',
                            'output_path',
                            'entitlements_paths',
                            'signer_class',

--- a/bin/isign
+++ b/bin/isign
@@ -160,8 +160,23 @@ def parse_args():
         metavar='<foo=bar>',
         help='Keyword=value arguments for signer module (can be used multiple times)',
     )
+    parser.add_argument(
+        '--adhoc',
+        required=False,
+        dest='adhoc',
+        action='store_true',
+        help='Sign adhoc (empty signature)'
+    )
 
     return parser.parse_args()
+
+
+def check_incompatible_args(args, check_against_argument, incompatible_args):
+    for k, v in vars(args).iteritems():
+        if k in incompatible_args and v is not None:
+            raise Exception("Incompatible arguments. Do not use any of " +
+                            ", ".join(['--' + s for s in incompatible_args])
+                            + " with the --{} argument.".format(check_against_argument))
 
 
 def filter_args(args, interested):
@@ -217,6 +232,19 @@ if __name__ == '__main__':
             if info_props:
                 kwargs['info_props'] = info_props
 
+        if args.adhoc:
+            # Handle adhoc resign. Credential files are irrelevant
+            check_incompatible_args(args, '--adhoc', ['apple_cert',
+                                                      'certificate',
+                                                      'key',
+                                                      'provisioning_profiles',
+                                                      'signer_class',
+                                                      'signer_arguments',
+                                                      'entitlements_paths'])
+            kwargs.update(filter_args(args, ['deep',
+                                             'output_path']))
+            isign.resign(app_path, **kwargs)
+
         if args.inplace:
             if args.output_path is not None:
                 raise Exception('output-path and inplace should not be both specified')
@@ -234,34 +262,10 @@ if __name__ == '__main__':
                     k, v = pair.split('=')
                     args.signer_arguments[k] = v
 
-        if args.fingerprint:
-            incompatible_args = ['certificate', 'key']
-            args_dict = vars(args)
-            for k, v in vars(args).iteritems():
-                if k in incompatible_args and v is not None:
-                    raise Exception("Incompatible arguments. Do not use any of " +
-                                    ", ".join(['--' + s for s in incompatible_args]) + " "
-                                    "with the --sign argument.")
-
-            if args.fingerprint != '-':
-                raise Exception("Currently only - (ad hoc) is supported as a fingerprint value.")
-            resign_args = ['deep',
-                           'output_path',
-                           'signer_class',
-                           'signer_arguments']
-            kwargs.update(filter_args(args, resign_args))
-            isign.resign(app_path, **kwargs)
-
-        elif args.credentials_dir:
+        if args.credentials_dir:
             # Handle a resign with credentials directory.
             # First check they haven't over-specified credential paths
-            incompatible_args = ['certificate', 'key', 'provisioning_profile']
-            args_dict = vars(args)
-            for k, v in vars(args).iteritems():
-                if k in incompatible_args and v is not None:
-                    raise Exception("Incompatible arguments. Do not use any of " +
-                                    ", ".join(['--' + s for s in incompatible_args]) + " "
-                                    "with the --credentials argument.")
+            check_incompatible_args(args, '--credentials_dir / -n', ['certificate', 'key', 'provisioning_profiles'])
             # looks good, now massage args into method arguments
             resign_args = ['apple_cert',
                            'deep',
@@ -282,7 +286,7 @@ if __name__ == '__main__':
                            'deep',
                            'key',
                            'apple_cert',
-			   'provisioning_profiles',
+                           'provisioning_profiles',
                            'output_path',
                            'entitlements_paths',
                            'signer_class',

--- a/isign/isign.py
+++ b/isign/isign.py
@@ -5,7 +5,7 @@ import exceptions
 import glob
 import os
 from os.path import dirname, exists, expanduser, join, realpath
-from signer import Pkcs1Signer, CmsSigner
+from signer import Pkcs1Signer, CmsSigner, AdhocCmsSigner
 from provisioner import Provisioner
 
 
@@ -62,6 +62,22 @@ def resign_with_creds_dir(input_path,
     kwargs.update({"provisioning_profiles": get_provisioning_profiles(credentials_directory)})
     kwargs.update({"entitlements_paths": get_entitlements_paths(credentials_directory)})
     return resign(input_path, **kwargs)
+
+
+def resign_adhoc(input_path,
+                 deep=True,
+                 output_path=join(os.getcwd(), "out"),
+                 info_props=None):
+    cms_signer = AdhocCmsSigner()
+    try:
+        return archive.resign(input_path,
+                              deep,
+                              cms_signer,
+                              None,  # no provisioner
+                              output_path,
+                              info_props)
+    except exceptions.NotSignable as e:
+        raise NotSignable(e)
 
 
 def resign(input_path,

--- a/isign/signer.py
+++ b/isign/signer.py
@@ -27,6 +27,11 @@ from openssl_shell import OpenSslShell
 log = logging.getLogger(__name__)
 
 
+# TODO: one day we need to refactor CmsSigner/AdhocCmsSigner and all the .is_adhoc() stuff into a "signing strategy"
+# Rather than embedding the knowledge of how to resign in all the archives/bundles/signables etc, group into a strategy
+# This would combine CmsSigner and Provisioner into one thing.
+
+
 class Pkcs1Signer(object):
     """ low-level PKCS#1 signer, which can be used by a CmsSigner to do
     the underlying signing operation """
@@ -235,7 +240,7 @@ class AdhocCmsSigner(CmsSigner):
     def __init__(self):
         pass
 
-    def sign(self, data):
+    def sign(self, oldsig, cd_hashes):
         """Return empty signature"""
         return ''
 

--- a/tests/test_adhoc.py
+++ b/tests/test_adhoc.py
@@ -11,17 +11,11 @@ class TestAdhoc(IsignBaseTest):
 
     def test_adhoc_signing(self):
         """
-        Ad-hoc signing is "identityless" signing. We indicate this by simply not providing the key.
-
-        These options were added by Facebook. It's not obvious if they still work.
-        This test looks like it should work, but doesn't because other parts of the code still want an
-        Entitlements file?
+        Ad-hoc signing is "identityless" signing.
         """
         output_path = self.get_temp_file()
-        isign.resign(self.TEST_IPA,
-                     key=None,
-                     provisioning_profiles=[IsignBaseTest.PROVISIONING_PROFILE],
-                     output_path=output_path)
+        isign.resign_adhoc(self.TEST_IPA,
+                           output_path=output_path)
         assert exists(output_path)
         assert os.path.getsize(output_path) > 0
         self.unlink(output_path)


### PR DESCRIPTION
Provided a new argument for adhoc signing, and a method which will create the (somewhat nonsensically named) AdhocCmsSigner

Added a comment that this is all rather silly and we should be talking about something like "standard signing strategy" and "adhoc strategy" instead, not CMS, and probably invert control. But that would be a HUGE refactor

n.b. I checked - when Mark Wang added this feature in, adhoc signing never needed, or could even use, provisioning profiles. So that is now eliminated.