### PR TITLE
CircleCI test fixes

### DIFF
--- a/tests/signing_service.py
+++ b/tests/signing_service.py
@@ -6,6 +6,7 @@ import json
 import os
 import pprint
 from signing_service_config import SigningServiceConfig
+import sys
 
 pp = pprint.PrettyPrinter(indent=4)
 CONFIG = SigningServiceConfig()
@@ -82,7 +83,11 @@ class SigningService(object):
     """ Server-side signer """
 
     @staticmethod
-    def start():
+    def start(quiet=False):
+        if quiet is True:
+            dev_null = open(os.devnull, 'w')
+            sys.stdout = dev_null
+            sys.stderr = dev_null
         print('Starting httpd at {}:{}...'.format(CONFIG.host, CONFIG.port))
         httpd = HTTPServer((CONFIG.host, CONFIG.port), SigningServiceHandler)
         httpd.serve_forever()

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -19,7 +19,7 @@ class TestRemoteSigner(IsignBaseTest):
         with open(os.devnull, 'w') as dev_null:
             test_dir = os.path.dirname(os.path.abspath(__file__))
             start_httpd_command = [sys.executable, os.path.join(test_dir, "signing_service.py")]
-            httpd_process = subprocess.Popen(start_httpd_command, stdout=dev_null, stderr=dev_null)
+            httpd_process = subprocess.Popen(start_httpd_command) # , stdout=dev_null, stderr=dev_null)
             # wait for httpd to start. As far as I know this is the simplest thing to do, without:
             #   - in the server, subclassing HTTPServer to print a message when ready (and even that's not reliable)
             #   - starting a thread and blocking here to wait for it
@@ -34,7 +34,6 @@ class TestRemoteSigner(IsignBaseTest):
 
         try:
             httpd_process = self.start_httpd()
-            time.sleep(10)
 
             isign.resign(
                 IsignBaseTest.TEST_IPA,

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -17,10 +17,10 @@ class TestRemoteSigner(IsignBaseTest):
     def start_httpd():
         signing_service = SigningService()
 
-        def start():
-            signing_service.start()
+        def start_signing_service():
+            signing_service.start(quiet=True)
 
-        httpd_process = Process(name='signing_service', target=start)
+        httpd_process = Process(name='signing_service', target=start_signing_service)
         httpd_process.daemon = True
         httpd_process.start()
         time.sleep(1)

--- a/tests/test_remote_signer.py
+++ b/tests/test_remote_signer.py
@@ -34,6 +34,7 @@ class TestRemoteSigner(IsignBaseTest):
 
         try:
             httpd_process = self.start_httpd()
+            time.sleep(10)
 
             isign.resign(
                 IsignBaseTest.TEST_IPA,

--- a/tests/test_signer_modules.py
+++ b/tests/test_signer_modules.py
@@ -11,7 +11,6 @@ log = logging.getLogger(__name__)
 class TestSignerModules(IsignBaseTest):
 
     def test_signer_class(self):
-
         calls = []  # Py2 won't allow to refer to outer scope by assignment, e.g. isCalled = True
 
         # To let the outer scope know a thing happened, must alter a mutable object - like an array!
@@ -21,12 +20,12 @@ class TestSignerModules(IsignBaseTest):
 
         output_path = self.get_temp_file()
 
-	isign.resign(
-	    IsignBaseTest.TEST_IPA,
-	    certificate=IsignBaseTest.CERTIFICATE,
-	    provisioning_profiles=[IsignBaseTest.PROVISIONING_PROFILE],
-	    output_path=output_path,
-	    signer_class=CallbackSigner,
-	    signer_arguments={'callback': callback}
-	)
-	assert len(calls) > 0
+        isign.resign(
+            IsignBaseTest.TEST_IPA,
+            certificate=IsignBaseTest.CERTIFICATE,
+            provisioning_profiles=[IsignBaseTest.PROVISIONING_PROFILE],
+            output_path=output_path,
+            signer_class=CallbackSigner,
+            signer_arguments={'callback': callback}
+        )
+        assert len(calls) > 0

--- a/tests/test_signer_modules.py
+++ b/tests/test_signer_modules.py
@@ -2,8 +2,6 @@ from isign import isign
 from isign_base_test import IsignBaseTest
 import logging
 from TestPythonLibDir.CallbackSigner import CallbackSigner
-from os.path import dirname, join, realpath
-import sys
 
 log = logging.getLogger(__name__)
 
@@ -22,10 +20,11 @@ class TestSignerModules(IsignBaseTest):
 
         isign.resign(
             IsignBaseTest.TEST_IPA,
+            key=None,
             certificate=IsignBaseTest.CERTIFICATE,
             provisioning_profiles=[IsignBaseTest.PROVISIONING_PROFILE],
             output_path=output_path,
             signer_class=CallbackSigner,
-            signer_arguments={'callback': callback}
+            signer_arguments={'callback': callback, 'keyfile': IsignBaseTest.KEY}
         )
         assert len(calls) > 0


### PR DESCRIPTION
* For Signer class tests, needed to specify key=None to get through the somewhat byzantine default argument replacements. Previously it had worked because developers always had a `~/.isign/key.pem` file.

* For remote signer tests, a shelled-out process `signing_service.py` was not able to import `signer`, possibly because the environment didn't have the right PYTHONPATH. Using `multiprocessing` fixed that.